### PR TITLE
Add Upstream and Target support

### DIFF
--- a/kong/apis.go
+++ b/kong/apis.go
@@ -25,8 +25,8 @@ type Apis struct {
 	Offset string `json:"offset,omitempty"`
 }
 
-// Api represents a single Kong api object.
-type Api struct {
+// ApiRequest represents a Kong api object for api creation.
+type ApiRequest struct {
 	UpstreamURL      string `json:"upstream_url,omitempty"`
 	StripRequestPath *bool  `json:"strip_request_path,omitempty"`
 	RequestPath      string `json:"request_path,omitempty"`
@@ -34,6 +34,19 @@ type Api struct {
 	CreatedAt        int64  `json:"created_at,omitempty"`
 	PreserveHost     bool   `json:"preserve_host,omitempty"`
 	Name             string `json:"name,omitempty"`
+	Hosts            string `json:"hosts,omitempty"`
+}
+
+// Api represents an existing Kong api object
+type Api struct {
+	UpstreamURL      string   `json:"upstream_url,omitempty"`
+	StripRequestPath *bool    `json:"strip_request_path,omitempty"`
+	RequestPath      string   `json:"request_path,omitempty"`
+	ID               string   `json:"id,omitempty"`
+	CreatedAt        int64    `json:"created_at,omitempty"`
+	PreserveHost     bool     `json:"preserve_host,omitempty"`
+	Name             string   `json:"name,omitempty"`
+	Hosts            []string `json:"hosts,omitempty"`
 }
 
 // Get queries for a single Kong api object, by name or id.
@@ -61,7 +74,7 @@ func (s *ApisService) Get(api string) (*Api, *http.Response, error) {
 // the passed *Api parameter.
 //
 // Equivalent to PATCH /apis/{name or id}
-func (s *ApisService) Patch(api *Api) (*http.Response, error) {
+func (s *ApisService) Patch(api *ApiRequest) (*http.Response, error) {
 	var u string
 	if api.Name != "" {
 		u = fmt.Sprintf("apis/%v", api.Name)
@@ -104,7 +117,7 @@ func (s *ApisService) Delete(api string) (*http.Response, error) {
 // Post creates a new Kong api object.
 //
 // Equivalent to POST /apis
-func (s *ApisService) Post(api *Api) (*http.Response, error) {
+func (s *ApisService) Post(api *ApiRequest) (*http.Response, error) {
 	req, err := s.client.NewRequest("POST", "apis", api)
 	if err != nil {
 		return nil, err

--- a/kong/apis_test.go
+++ b/kong/apis_test.go
@@ -77,10 +77,10 @@ func TestApisService_Patch_byName(t *testing.T) {
 	stubSetup()
 	defer stubTeardown()
 
-	input := &Api{Name: "n"}
+	input := &ApiRequest{Name: "n"}
 
 	mux.HandleFunc("/apis/n", func(w http.ResponseWriter, r *http.Request) {
-		v := new(Api)
+		v := new(ApiRequest)
 		json.NewDecoder(r.Body).Decode(v)
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
@@ -100,10 +100,10 @@ func TestApisService_Patch_byID(t *testing.T) {
 	stubSetup()
 	defer stubTeardown()
 
-	input := &Api{ID: "i"}
+	input := &ApiRequest{ID: "i"}
 
 	mux.HandleFunc("/apis/i", func(w http.ResponseWriter, r *http.Request) {
-		v := new(Api)
+		v := new(ApiRequest)
 		json.NewDecoder(r.Body).Decode(v)
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
@@ -120,13 +120,13 @@ func TestApisService_Patch_byID(t *testing.T) {
 }
 
 func TestApisService_Patch_invalidApi(t *testing.T) {
-	input := &Api{Name: "%"}
+	input := &ApiRequest{Name: "%"}
 	_, err := client.Apis.Patch(input)
 	testURLParseError(t, err)
 }
 
 func TestApisService_Patch_missingIDOrName(t *testing.T) {
-	input := &Api{RequestPath: "r"}
+	input := &ApiRequest{RequestPath: "r"}
 	_, err := client.Apis.Patch(input)
 	if err == nil {
 		t.Error("Expected error to be returned")
@@ -142,7 +142,7 @@ func TestApisService_Patch_badStatusCode(t *testing.T) {
 		fmt.Fprint(w, `{"error":"e"}`)
 	})
 
-	input := &Api{ID: "i"}
+	input := &ApiRequest{ID: "i"}
 
 	_, err := client.Apis.Patch(input)
 	if err == nil {
@@ -188,10 +188,10 @@ func TestApisService_Post(t *testing.T) {
 	stubSetup()
 	defer stubTeardown()
 
-	input := &Api{ID: "i"}
+	input := &ApiRequest{ID: "i"}
 
 	mux.HandleFunc("/apis", func(w http.ResponseWriter, r *http.Request) {
-		v := new(Api)
+		v := new(ApiRequest)
 		json.NewDecoder(r.Body).Decode(v)
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
@@ -216,7 +216,7 @@ func TestApisService_Post_badStatusCode(t *testing.T) {
 		fmt.Fprint(w, `{"error":"e"}`)
 	})
 
-	input := &Api{ID: "i"}
+	input := &ApiRequest{ID: "i"}
 
 	_, err := client.Apis.Post(input)
 	if err == nil {

--- a/kong/kong.go
+++ b/kong/kong.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/google/go-querystring/query"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
+
+	"github.com/google/go-querystring/query"
 )
 
 const (
@@ -39,6 +40,8 @@ type Client struct {
 	Node      *NodeService
 	Cluster   *ClusterService
 	Apis      *ApisService
+	Upstreams *UpstreamsService
+	Targets   *TargetsService
 	Consumers *ConsumersService
 	Plugins   *PluginsService
 }
@@ -101,6 +104,12 @@ func NewClient(httpClient *http.Client, baseURLStr string) (*Client, error) {
 	c.Apis = &ApisService{
 		service: &c.common,
 		Plugins: (*ApisPluginsService)(&c.common),
+	}
+	c.Upstreams = &UpstreamsService{
+		service: &c.common,
+	}
+	c.Targets = &TargetsService{
+		service: &c.common,
 	}
 	c.Consumers = &ConsumersService{
 		service: &c.common,

--- a/kong/targets.go
+++ b/kong/targets.go
@@ -41,7 +41,7 @@ type Target struct {
 	UpstreamID string `json:"upstream_id,omitempty"`
 }
 
-// GetAllActive lists all the active targets attached to the specifed upstream.
+// GetAllActive lists all the active targets attached to the specified upstream.
 //
 // Equivalent to GET/upstreams/{name or id}/targets/active
 func (s *TargetsService) GetAllActive(upstream string) (*Targets, *http.Response, error) {

--- a/kong/targets.go
+++ b/kong/targets.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 )
 
-// TargetsService handles communication with Kong's '/targets' resource.
+// TargetsService handles communication with Kong's '/upstreams/{name or id}/targets' resource.
 type TargetsService struct {
 	*service
 }

--- a/kong/targets.go
+++ b/kong/targets.go
@@ -1,0 +1,125 @@
+package kong
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+// TargetsService handles communication with Kong's '/targets' resource.
+type TargetsService struct {
+	*service
+}
+
+// Targets represents the object returned from Kong when querying for
+// multiple target objects.
+//
+// In cases where the number of objects returned exceeds the maximum,
+// Next holds the URI for the next set of results.
+// i.e. "http://localhost:8001/targets/?size=2&offset=4d924084-1adb-40a5-c042-63b19db421d1"
+type Targets struct {
+	Data   []*Target `json:"data,omitempty"`
+	Total  int       `json:"total,omitempty"`
+	Next   string    `json:"next,omitempty"`
+	Offset string    `json:"offset,omitempty"`
+}
+
+// TargetCount represents the number of targets on an upstream
+type TargetCount struct {
+	Total int `json:"total"`
+}
+
+// Target represents a single Kong target object.
+type Target struct {
+	Target     string `json:"target"`
+	ID         string `json:"id,omitempty"`
+	CreatedAt  int64  `json:"created_at,omitempty"`
+	Weight     int    `json:"weight,omitempty"`
+	UpstreamID string `json:"upstream_id,omitempty"`
+}
+
+// GetAllActive lists all the active targets attached to the specifed upstream.
+//
+// Equivalent to GET/upstreams/{name or id}/targets/active
+func (s *TargetsService) GetAllActive(upstream string) (*Targets, *http.Response, error) {
+	u := fmt.Sprintf("upstreams/%v/targets/active", upstream)
+
+	req, err := s.client.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	uResp := new(Targets)
+	targetCount := new(TargetCount)
+	// The targets/active endpoint has a bug where no results is manifest by data: {} instead of data: []
+	// This is a workaround for this issue
+	resp, err := s.client.Do(req, nil)
+	if err != nil {
+		return nil, resp, err
+	}
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	err = json.NewDecoder(bytes.NewReader(respBody)).Decode(targetCount)
+	if err == io.EOF {
+		err = nil
+	}
+	if err != nil {
+		return nil, resp, err
+	}
+
+	if targetCount.Total != 0 {
+		// It is safe to cast to full Targets list
+		err = json.NewDecoder(bytes.NewReader(respBody)).Decode(uResp)
+	} else {
+		uResp.Data = []*Target{}
+		uResp.Total = 0
+	}
+	if err == io.EOF {
+		err = nil
+	}
+
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return uResp, resp, err
+}
+
+// Delete deletes a single Kong target object, by target (host/port combination)
+//
+// Equivalent to DELETE /upstreams/{name or id}/targets/{target}
+func (s *TargetsService) Delete(upstream string, target string) (*http.Response, error) {
+	u := fmt.Sprintf("upstreams/%v/targets/%v", upstream, target)
+
+	req, err := s.client.NewRequest(http.MethodDelete, u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, err
+}
+
+// Post creates a new Kong target object.
+//
+// Equivalent to POST /upstreams/{name or id}/targets
+func (s *TargetsService) Post(upstream string, target *Target) (*http.Response, error) {
+	req, err := s.client.NewRequest(http.MethodPost, fmt.Sprintf("upstreams/%v/targets", upstream), target)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(req, nil)
+
+	return resp, err
+}

--- a/kong/targets_test.go
+++ b/kong/targets_test.go
@@ -1,0 +1,152 @@
+package kong
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+var upstreamName = "testupstream"
+
+func TestTargets_Delete(t *testing.T) {
+	stubSetup()
+	defer stubTeardown()
+
+	mux.HandleFunc(fmt.Sprintf("/upstreams/%s/targets/i", upstreamName), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+	})
+
+	_, err := client.Targets.Delete(upstreamName, "i")
+	if err != nil {
+		t.Errorf("Targets.Delete returned error: %v", err)
+	}
+}
+
+func TestTargets_Delete_invalidTarget(t *testing.T) {
+	stubSetup()
+	defer stubTeardown()
+
+	_, err := client.Targets.Delete(upstreamName, "%")
+	testURLParseError(t, err)
+}
+
+func TestTargets_Delete_badStatusCode(t *testing.T) {
+	stubSetup()
+	defer stubTeardown()
+
+	mux.HandleFunc(fmt.Sprintf("/upstreams/%s/targets/i", upstreamName), func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+		fmt.Fprint(w, `{"error":"e"}`)
+	})
+
+	_, err := client.Targets.Delete(upstreamName, "i")
+	if err == nil {
+		t.Error("Expected error to be returned")
+	}
+}
+
+func TestTargets_Post(t *testing.T) {
+	stubSetup()
+	defer stubTeardown()
+
+	input := sampleTarget()
+
+	mux.HandleFunc(fmt.Sprintf("/upstreams/%s/targets", upstreamName), func(w http.ResponseWriter, r *http.Request) {
+		v := new(Target)
+		json.NewDecoder(r.Body).Decode(v)
+		if !reflect.DeepEqual(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+
+		testMethod(t, r, "POST")
+	})
+
+	_, err := client.Targets.Post(upstreamName, input)
+	if err != nil {
+		t.Errorf("Targets.Post returned error: %v", err)
+	}
+}
+
+func TestTargets_Post_badStatusCode(t *testing.T) {
+	stubSetup()
+	defer stubTeardown()
+
+	mux.HandleFunc(fmt.Sprintf("/upstreams/%s/targets", upstreamName), func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+		fmt.Fprint(w, `{"error":"e"}`)
+	})
+
+	input := sampleTarget()
+
+	_, err := client.Targets.Post(upstreamName, input)
+	if err == nil {
+		t.Error("Expected error to be returned")
+	}
+}
+
+func TestTargets_GetAllActive(t *testing.T) {
+	stubSetup()
+	defer stubTeardown()
+
+	v := &Targets{Total: 1, Next: "n", Data: []*Target{sampleTarget()}}
+
+	mux.HandleFunc(fmt.Sprintf("/upstreams/%s/targets/active", upstreamName), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		json.NewEncoder(w).Encode(v)
+	})
+
+	targets, _, err := client.Targets.GetAllActive(upstreamName)
+	if err != nil {
+		t.Errorf("Targets.GetAllActive returned error: %v", err)
+	}
+
+	if !reflect.DeepEqual(targets, v) {
+		t.Errorf("Targets.GetAllActive returned %+v, want %+v", targets, v)
+	}
+}
+
+func TestTargets_GetAllActive_NoneActive(t *testing.T) {
+	stubSetup()
+	defer stubTeardown()
+
+	v := &Targets{Total: 0, Data: []*Target{}}
+
+	mux.HandleFunc(fmt.Sprintf("/upstreams/%s/targets/active", upstreamName), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		json.NewEncoder(w).Encode(v)
+	})
+
+	targets, _, err := client.Targets.GetAllActive(upstreamName)
+	if err != nil {
+		t.Errorf("Targets.GetAllActive returned error: %v", err)
+	}
+
+	if !reflect.DeepEqual(targets, v) {
+		t.Errorf("Targets.GetAllActive returned %+v, want %+v", targets, v)
+	}
+}
+
+func TestTargets_GetAllActive_badStatusCode(t *testing.T) {
+	stubSetup()
+	defer stubTeardown()
+
+	mux.HandleFunc(fmt.Sprintf("/upstreams/%s/targets/active", upstreamName), func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+		fmt.Fprint(w, `{"error":"e"}`)
+	})
+
+	_, _, err := client.Targets.GetAllActive(upstreamName)
+	if err == nil {
+		t.Error("Expected error to be returned")
+	}
+}
+
+func sampleTarget() *Target {
+	return &Target{
+		Target: "service:80",
+		Weight: 34,
+	}
+
+}

--- a/kong/upstreams.go
+++ b/kong/upstreams.go
@@ -1,0 +1,113 @@
+package kong
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// UpstreamsService handles communication with Kong's '/upstreams' resource.
+type UpstreamsService struct {
+	*service
+}
+
+// Upstreams represents the object returned from Kong when querying for
+// multiple upstream objects.
+//
+// In cases where the number of objects returned exceeds the maximum,
+// Next holds the URI for the next set of results.
+// i.e. "http://localhost:8001/upstreams/?size=2&offset=4d924084-1adb-40a5-c042-63b19db421d1"
+type Upstreams struct {
+	Data   []*Upstream `json:"data,omitempty"`
+	Total  int         `json:"total,omitempty"`
+	Next   string      `json:"next,omitempty"`
+	Offset string      `json:"offset,omitempty"`
+}
+
+// Upstream represents a single Kong upstream object.
+type Upstream struct {
+	Name      string `json:"name"`
+	ID        string `json:"id,omitempty"`
+	CreatedAt int64  `json:"created_at,omitempty"`
+	Slots     int    `json:"slots,omitempty"`
+	Orderlist []int  `json:"orderliste,omitempty"`
+}
+
+// Get queries for a single Kong upstream object, by name or id.
+//
+// Equivalent to GET /upstreams/{name or id}
+func (s *UpstreamsService) Get(upstream string) (*Upstream, *http.Response, error) {
+	u := fmt.Sprintf("upstreams/%v", upstream)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	uResp := new(Upstream)
+	resp, err := s.client.Do(req, uResp)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return uResp, resp, err
+}
+
+// Patch updates an existing Kong upstream object.
+// At least one of upstream.Name or upstream.ID must be specified in
+// the passed *Upstream parameter.
+//
+// Equivalent to PATCH /upstreams/{name or id}
+func (s *UpstreamsService) Patch(upstream *Upstream) (*http.Response, error) {
+	var u string
+	if upstream.Name != "" {
+		u = fmt.Sprintf("upstreams/%v", upstream.Name)
+	} else if upstream.ID != "" {
+		u = fmt.Sprintf("upstreams/%v", upstream.ID)
+	} else {
+		return nil, errors.New("At least one of upstream.Name or upstream.ID must be specified")
+	}
+
+	req, err := s.client.NewRequest("PATCH", u, upstream)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(req, nil)
+
+	return resp, err
+
+}
+
+// Delete deletes a single Kong upstream object, by name or id.
+//
+// Equivalent to DELETE /upstreams/{name or id}
+func (s *UpstreamsService) Delete(upstream string) (*http.Response, error) {
+	u := fmt.Sprintf("upstreams/%v", upstream)
+
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, err
+}
+
+// Post creates a new Kong upstream object.
+//
+// Equivalent to POST /upstreams
+func (s *UpstreamsService) Post(upstream *Upstream) (*http.Response, error) {
+	req, err := s.client.NewRequest("POST", "upstreams", upstream)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(req, nil)
+
+	return resp, err
+}

--- a/kong/upstreams_test.go
+++ b/kong/upstreams_test.go
@@ -94,6 +94,7 @@ func TestUpstreams_Patch_byID(t *testing.T) {
 		t.Errorf("Upstreams.Patch returned error: %v", err)
 	}
 }
+
 func TestUpstream_Patch_invalidUpstream(t *testing.T) {
 	stubSetup()
 	defer stubTeardown()

--- a/kong/upstreams_test.go
+++ b/kong/upstreams_test.go
@@ -1,0 +1,214 @@
+package kong
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestUpstream_Get(t *testing.T) {
+	stubSetup()
+	defer stubTeardown()
+
+	mux.HandleFunc("/upstreams/i", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"id":"i"}`)
+	})
+
+	upstream, _, err := client.Upstreams.Get("i")
+	if err != nil {
+		t.Errorf("Upstreams.Get returned error: %v", err)
+	}
+
+	want := &Upstream{ID: "i"}
+	if !reflect.DeepEqual(upstream, want) {
+		t.Errorf("Upstreams.Get returned %+v, want %+v", upstream, want)
+	}
+}
+
+func TestUpstream_Get_invalidUpstream(t *testing.T) {
+	stubSetup()
+	defer stubTeardown()
+
+	_, _, err := client.Upstreams.Get("%")
+	testURLParseError(t, err)
+}
+
+func TestUpstream_Get_badStatusCode(t *testing.T) {
+	stubSetup()
+	defer stubTeardown()
+
+	mux.HandleFunc("/upstreams/i", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+		fmt.Fprint(w, `{"error":"e"}`)
+	})
+
+	_, _, err := client.Upstreams.Get("i")
+	if err == nil {
+		t.Error("Expected error to be returned")
+	}
+}
+
+func TestUpstreams_Patch_byName(t *testing.T) {
+	stubSetup()
+	defer stubTeardown()
+
+	input := sampleUpstream()
+
+	mux.HandleFunc("/upstreams/"+input.Name, func(w http.ResponseWriter, r *http.Request) {
+		v := new(Upstream)
+		json.NewDecoder(r.Body).Decode(v)
+		if !reflect.DeepEqual(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+
+		testMethod(t, r, "PATCH")
+	})
+
+	_, err := client.Upstreams.Patch(input)
+	if err != nil {
+		t.Errorf("Upstreams.Patch returned error: %v", err)
+	}
+}
+
+func TestUpstreams_Patch_byID(t *testing.T) {
+	stubSetup()
+	defer stubTeardown()
+
+	input := sampleUpstream()
+
+	mux.HandleFunc("/upstreams/"+input.Name, func(w http.ResponseWriter, r *http.Request) {
+		v := new(Upstream)
+		json.NewDecoder(r.Body).Decode(v)
+		if !reflect.DeepEqual(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+
+		testMethod(t, r, "PATCH")
+	})
+
+	_, err := client.Upstreams.Patch(input)
+	if err != nil {
+		t.Errorf("Upstreams.Patch returned error: %v", err)
+	}
+}
+func TestUpstream_Patch_invalidUpstream(t *testing.T) {
+	stubSetup()
+	defer stubTeardown()
+
+	input := &Upstream{Name: "%"}
+	_, err := client.Upstreams.Patch(input)
+	testURLParseError(t, err)
+}
+
+func TestUpstream_Patch_missingIDOrName(t *testing.T) {
+	stubSetup()
+	defer stubTeardown()
+
+	input := &Upstream{Slots: 100}
+	_, err := client.Upstreams.Patch(input)
+	if err == nil {
+		t.Error("Expected error to be returned")
+	}
+}
+
+func TestUpstream_Patch_badStatusCode(t *testing.T) {
+	stubSetup()
+	defer stubTeardown()
+
+	mux.HandleFunc("/upstreams/i", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+		fmt.Fprint(w, `{"error":"e"}`)
+	})
+
+	input := sampleUpstream()
+
+	_, err := client.Upstreams.Patch(input)
+	if err == nil {
+		t.Error("Expected error to be returned")
+	}
+}
+
+func TestUpstream_Delete(t *testing.T) {
+	stubSetup()
+	defer stubTeardown()
+
+	mux.HandleFunc("/upstreams/i", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+	})
+
+	_, err := client.Upstreams.Delete("i")
+	if err != nil {
+		t.Errorf("Upstreams.Delete returned error: %v", err)
+	}
+}
+
+func TestUpstream_Delete_invalidUpstream(t *testing.T) {
+	_, err := client.Upstreams.Delete("%")
+	testURLParseError(t, err)
+}
+
+func TestUpstream_Delete_badStatusCode(t *testing.T) {
+	stubSetup()
+	defer stubTeardown()
+
+	mux.HandleFunc("/upstreams/i", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+		fmt.Fprint(w, `{"error":"e"}`)
+	})
+
+	_, err := client.Upstreams.Delete("i")
+	if err == nil {
+		t.Error("Expected error to be returned")
+	}
+}
+
+func TestUpstream_Post(t *testing.T) {
+	stubSetup()
+	defer stubTeardown()
+
+	input := sampleUpstream()
+
+	mux.HandleFunc("/upstreams", func(w http.ResponseWriter, r *http.Request) {
+		v := new(Upstream)
+		json.NewDecoder(r.Body).Decode(v)
+		if !reflect.DeepEqual(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+
+		testMethod(t, r, "POST")
+	})
+
+	_, err := client.Upstreams.Post(input)
+	if err != nil {
+		t.Errorf("Upstreams.Post returned error: %v", err)
+	}
+}
+
+func TestUpstream_Post_badStatusCode(t *testing.T) {
+	stubSetup()
+	defer stubTeardown()
+
+	mux.HandleFunc("/upstreams", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+		fmt.Fprint(w, `{"error":"e"}`)
+	})
+
+	input := sampleUpstream()
+
+	_, err := client.Upstreams.Post(input)
+	if err == nil {
+		t.Error("Expected error to be returned")
+	}
+}
+
+func sampleUpstream() *Upstream {
+	return &Upstream{
+		Name:      "upstreamName",
+		ID:        "upstreamID",
+		Slots:     4,
+		Orderlist: []int{4, 1, 3, 2},
+	}
+}


### PR DESCRIPTION
Added non-comprehensive support for interacting with the Kong Upstream and Target APIs (see https://getkong.org/docs/0.10.x/admin-api)